### PR TITLE
add --size option: delete all files larger than the specified size

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Options:
   -V, --version        output the version number
   -t, --token <token>  Your Slack API token (required)
   -x, --types <items>  A list of filetypes (e.g. "png,jpg,mp3") to delete
+  -s, --size <size>    All files above the specified size will be deleted
   -d, --dry            Perform a dry run only
   -l, --list           List all files on Slack ordered by filesize
 ```
@@ -31,6 +32,11 @@ Perform a dry run deleting all files with filetypes jpg, png or gif:
 
 `./index.js -t abcd-0123456789-0123456789-0123456789-0123456abc -x jpg,png,gif -d`
 
-List all files visible to the user associated with the token
+Delete all files larger than 100 megabytes:
+
+`./index.js -t abcd-0123456789-0123456789-0123456789-0123456abc -s 100M`
+
+List all files visible to the user associated with the token:
 
 `./index.js -t abcd-0123456789-0123456789-0123456789-0123456abc -l`
+

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function prettyPrint(files) {
     return total + (file.size * 1);
   }, 0);
 
-  console.log('Total:', humanFormat(file.size, {scale: 'binary',  unit: 'B'}));
+  console.log('Total:', humanFormat(totalSize, {scale: 'binary',  unit: 'B'}));
 }
 
 function cleanFiles(files) {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,12 @@ if (program.types) {
 }
 
 if(program.size) {
-  var parsed=humanFormat.parse.raw(program.size);
+  try {
+    var parsed=humanFormat.parse.raw(program.size);
+  } catch (e) {
+    console.error('\'',program.size,'\' is not a valid file size (examples: 100MiB, 42kB).')
+    process.exit(1);
+  }
   if (!(parsed.unit == '' || parsed.unit.toLowerCase() == 'b' || parsed.unit.toLowerCase() == 'ib')) {
     console.error('\'',parsed.unit,'\' is not a valid unit for file sizes (valid examples: 100MiB, 42kB).');
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "console.table": "^0.4.0",
-    "filesize": "^3.1.4",
+    "human-format": "^0.7.0",
     "lodash": "^3.10.1",
     "request": "^2.67.0"
   }


### PR DESCRIPTION
We had some rather big files on our slack than some people shared. Instead of deleting files by type or age I wanted to delete all files that were above a certain size.
 
**Example:** 
```
> ./index.js --token xoxp-XXXXX-XXXXX-XXXXX-XXXXX --size 25M
All files with a filesize above this value will be deleted: 25 MiB
Fetching files: 13%
Fetching files: 25%
Fetching files: 38%
Fetching files: 50%
Fetching files: 63%
Fetching files: 75%
Fetching files: 88%
Fetching files: 100%
Deleting files larger than 25 MiB
Deleting:  pdf XXXXX.pdf
Deleting:  mp4 XXXXX.mp4
Deleting:  mp4 XXXXX.mp4
Deleting:  mp4 XXXXX.mp4
Deleting:  mp4 XXXXX.mp4
Deleting:  pptx XXXXX.pptx
Deleting:  pptx XXXXX.pptx
Deleting:  zip XXXXX.zip
Deleting:  binary XXXXX.avi
Deleting:  apk XXXXX.apk
Deleting:  mp4 XXXXX.mp4
Deleting:  apk XXXXX.apk
Deleting:  apk XXXXX.apk
Deleting:  binary XXXXX.avi
Deleted: 14 files (1.15 GiB)
```
--size supports different notations for filesize (42M, 42kB, 0.42GiB, etc.)

**Additional changes:**
- switched from `filesize` to `human-format` (enables parsing of filesize input)
- removed `\r` from first line (was `\r\n`, is now `\n`) as it would not run under linux otherwise. If there is no particular reason for using `\r\n` I would recommend removing the carriage return.